### PR TITLE
OT98 84: Agregar Documentacion con Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ So, make sure to set up your IDE with the right code style format file.
 ### SWAGGER DOCUMENTATION
 
 If you want to display the API documentation, run the below command and then go
-to: http://localhost:8080/api/docs/swagger-ui/
+to: http://localhost:8080/api/docs/swagger-ui/ and look up for: /api/docs.
 
 ```
 mvn spring-boot:run

--- a/pom.xml
+++ b/pom.xml
@@ -118,13 +118,13 @@
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger2</artifactId>
-      <version>3.0.0</version>
+      <version>2.9.2</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui -->
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>
-      <version>3.0.0</version>
+      <version>2.9.2</version>
     </dependency>
   </dependencies>
   <description>ONG project with Spring Boot</description>

--- a/pom.xml
+++ b/pom.xml
@@ -118,13 +118,13 @@
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger2</artifactId>
-      <version>2.9.2</version>
+      <version>3.0.0</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui -->
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>
-      <version>2.9.2</version>
+      <version>3.0.0</version>
     </dependency>
   </dependencies>
   <description>ONG project with Spring Boot</description>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,18 @@
       <groupId>com.amazonaws</groupId>
       <version>1.12.99</version>
     </dependency>
-
+    <!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger2 -->
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger2</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui -->
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger-ui</artifactId>
+      <version>3.0.0</version>
+    </dependency>
   </dependencies>
   <description>ONG project with Spring Boot</description>
   <groupId>com.alkemy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,13 +114,16 @@
       <groupId>com.amazonaws</groupId>
       <version>1.12.99</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger2 -->
     <dependency>
       <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger2</artifactId>
+      <artifactId>springfox-boot-starter</artifactId>
       <version>3.0.0</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui -->
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger2 </artifactId>
+      <version>3.0.0</version>
+    </dependency>
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,21 +129,6 @@
       <artifactId>springdoc-openapi-security</artifactId>
       <version>1.5.12</version>
     </dependency>
-    <dependency>
-      <artifactId>springfox-boot-starter</artifactId>
-      <groupId>io.springfox</groupId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <artifactId>springfox-swagger2</artifactId>
-      <groupId>io.springfox</groupId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <artifactId>springfox-swagger-ui</artifactId>
-      <groupId>io.springfox</groupId>
-      <version>3.0.0</version>
-    </dependency>
   </dependencies>
   <description>ONG project with Spring Boot</description>
   <groupId>com.alkemy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,19 +115,19 @@
       <version>1.12.99</version>
     </dependency>
     <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-boot-starter</artifactId>
-      <version>3.0.0</version>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-ui</artifactId>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger2 </artifactId>
-      <version>3.0.0</version>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-data-rest</artifactId>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger-ui</artifactId>
-      <version>3.0.0</version>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-security</artifactId>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
   <description>ONG project with Spring Boot</description>

--- a/src/main/java/com/alkemy/ong/OngApplication.java
+++ b/src/main/java/com/alkemy/ong/OngApplication.java
@@ -1,11 +1,13 @@
 package com.alkemy.ong;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 @EnableAutoConfiguration
+@OpenAPIDefinition
 public class OngApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -56,6 +56,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers(HttpMethod.POST, "/auth/login", "/auth/register")
         .permitAll()
+        .antMatchers("/swagger-ui.html", "/v2/api-docs")
+        .permitAll()
         .antMatchers(HttpMethod.GET, "/organization/public")
         .hasAnyRole(ApplicationRole.USER.getName(), ApplicationRole.ADMIN.getName())
         .antMatchers(HttpMethod.GET, "/auth/me")

--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers(HttpMethod.POST, "/auth/login", "/auth/register")
         .permitAll()
         .antMatchers("/swagger-resources/**", "/swagger-ui/**", "/v2/api-docs",
-            "/api/docs", "/api/docs/**")
+            "/api/docs", "/api/docs/**", "/v3/api-docs", "/api/docs/swagger-ui.html")
         .permitAll()
         .antMatchers(HttpMethod.GET, "/organization/public")
         .hasAnyRole(ApplicationRole.USER.getName(), ApplicationRole.ADMIN.getName())

--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -27,8 +27,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       "/swagger-ui/**", "/v2/api-docs",
       "/api/docs",
       "/api/docs/**",
-      "/v3/api-docs",
-      "/api/docs/swagger-ui.html"};
+      "/v3/api-docs/**",
+      "/api/docs/swagger-ui",
+      "/swagger-ui.html"};
 
   @Autowired
   private UserDetailsService userDetailsService;
@@ -65,8 +66,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers(SWAGGER)
         .permitAll()
         .antMatchers(HttpMethod.POST, "/auth/login", "/auth/register")
-        .permitAll()
-        .antMatchers(SWAGGER)
         .permitAll()
         .antMatchers(HttpMethod.GET, "/organization/public")
         .hasAnyRole(ApplicationRole.USER.getName(), ApplicationRole.ADMIN.getName())

--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers(HttpMethod.POST, "/auth/login", "/auth/register")
         .permitAll()
-        .antMatchers("/swagger-ui.html", "/v2/api-docs")
+        .antMatchers("/swagger-resources/**", "/swagger-ui/**", "/v2/api-docs",
+            "/api/docs", "/api/docs/**")
         .permitAll()
         .antMatchers(HttpMethod.GET, "/organization/public")
         .hasAnyRole(ApplicationRole.USER.getName(), ApplicationRole.ADMIN.getName())

--- a/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
@@ -26,9 +26,9 @@ public class SwaggerConfig {
 
   private ApiInfo apiInfo() {
     return new ApiInfoBuilder()
-        .title("SOMOS MAS")
-        .description("Ong destinada a mejorar la calidad de vida de niños y familias en "
-            + "situacion de vulnerabilidad")
+        .title("Somos Mas")
+        .description("Social Organization aimed to helping children and families "
+            + "in vulnerable situations")
         .build();
   }
 

--- a/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.alkemy.ong.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+  @Bean
+  public Docket swagger() {
+    return new Docket(DocumentationType.SWAGGER_2)
+        .select()
+        .apis(RequestHandlerSelectors.basePackage("com.alkemy.ong"))
+        .paths(PathSelectors.any())
+        .build()
+        .apiInfo(apiInfo());
+  }
+
+  private ApiInfo apiInfo() {
+    return new ApiInfoBuilder()
+        .title("SOMOS MAS")
+        .description("Ong destinada a mejorar la calidad de vida de niños y familias en "
+            + "situacion de vulnerabilidad")
+        .build();
+  }
+
+}

--- a/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
@@ -1,35 +1,16 @@
 package com.alkemy.ong.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
 
   @Bean
-  public Docket swagger() {
-    return new Docket(DocumentationType.SWAGGER_2)
-        .select()
-        .apis(RequestHandlerSelectors.basePackage("com.alkemy.ong.controller"))
-        .paths(PathSelectors.any())
-        .build()
-        .apiInfo(apiInfo());
+  public OpenAPI api() {
+    return new OpenAPI()
+        .info(new Info().title("Prueba"));
   }
-
-  private ApiInfo apiInfo() {
-    return new ApiInfoBuilder()
-        .title("Somos Mas")
-        .description("Social Organization aimed to helping children and families "
-            + "in vulnerable situations")
-        .build();
-  }
-
 }

--- a/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
@@ -18,7 +18,7 @@ public class SwaggerConfig {
   public Docket swagger() {
     return new Docket(DocumentationType.SWAGGER_2)
         .select()
-        .apis(RequestHandlerSelectors.basePackage("com.alkemy.ong"))
+        .apis(RequestHandlerSelectors.basePackage("com.alkemy.ong.controller"))
         .paths(PathSelectors.any())
         .build()
         .apiInfo(apiInfo());

--- a/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
@@ -1,27 +1,12 @@
 package com.alkemy.ong.config;
 
 
-import java.util.Arrays;
-import java.util.List;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.AuthorizationScope;
-import springfox.documentation.service.SecurityReference;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spi.service.contexts.SecurityContext;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
-@EnableSwagger2
-@Import(BeanValidatorPluginsConfiguration.class)
 public class SwaggerConfig {
 
   private static final String BASE_PACKAGE = "com.alkemy.ong.controller";
@@ -35,45 +20,12 @@ public class SwaggerConfig {
       + "families in vulnerable situations";
 
   @Bean
-  public Docket api() {
-    return new Docket(DocumentationType.SWAGGER_2)
-        .apiInfo(getApiInfo())
-        .securityContexts(Arrays.asList(securityContext()))
-        .securitySchemes(Arrays.asList(apiKey()))
-        .select()
-        .apis(RequestHandlerSelectors.basePackage(BASE_PACKAGE))
-        .paths(PathSelectors.any())
-        .build();
-  }
-
-  private ApiKey apiKey() {
-    return new ApiKey(API_KEY_NAME, API_KEY_KEYNAME, API_KEY_PASS_AS);
-  }
-
-  private SecurityContext securityContext() {
-    return SecurityContext.builder().securityReferences(defaultAuth()).build();
-  }
-
-  private List<SecurityReference> defaultAuth() {
-    AuthorizationScope authorizationScope = new AuthorizationScope(SCOPE, SCOPE_DESCRIPTION);
-    AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
-    authorizationScopes[0] = authorizationScope;
-    return Arrays.asList(new SecurityReference(API_KEY_NAME, authorizationScopes));
-  }
-
-  private ApiInfo getApiInfo() {
-    return new ApiInfoBuilder()
-        .title(TITLE)
-        .description(DESCRIPTION)
-        .build();
-  }
-
-  /*
-  @Bean
   public OpenAPI api() {
     return new OpenAPI()
-        .info(new Info().title("Prueba"));
+        .info(new Info()
+            .title(TITLE)
+            .description(DESCRIPTION)
+        );
   }
-  */
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,9 +13,11 @@ email.sender.sendgrid.token=foo
 # jackson serializable
 spring.jackson.serialization.wrap-root-value=true
 # swagger-ui custom path
-springdoc.swagger-ui.path=/api/docs/swagger-ui.html
+springdoc.swagger-ui.path=/api/docs/swagger-ui
 # /api-docs endpoint custom path
 springdoc.api-docs.path=/api/docs
 # Packages to include
 springdoc.packagesToScan=com.alkemy.ong.controller
+# Disable example
+springdoc.swagger-ui.disable-swagger-default-url=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,10 @@ email.sender.sendgrid.token=foo
 
 # jackson serializable
 spring.jackson.serialization.wrap-root-value=true
+
+# swagger-ui custom path
+springdoc.swagger-ui.path=/api/docs/swagger-ui.html
+# /api-docs endpoint custom path
+springdoc.api-docs.path=/api/docs
+# Packages to include
+springdoc.packagesToScan=com.alkemy.ong.controller

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,9 +10,9 @@ spring.jpa.hibernate.ddl-auto=update
 # Email sender attributes
 email.sender.from=alkemyot98@gmail.com
 email.sender.sendgrid.token=foo
-# jackson serializable
+# Jackson serializable
 spring.jackson.serialization.wrap-root-value=true
-# swagger-ui custom path
+# Swagger-ui custom path
 springdoc.swagger-ui.path=/api/docs/swagger-ui
 # /api-docs endpoint custom path
 springdoc.api-docs.path=/api/docs

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,10 +5,3 @@ amazonProperties:
   region: sa-east-1
   bucketName: alkemy-ong
 
-springfox:
-  documentation:
-    swaggerUi:
-      baseUrl: /api/docs
-    swagger:
-      v2:
-        path: /api/docs

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,3 +4,11 @@ amazonProperties:
   secretAccessKey: foo
   region: sa-east-1
   bucketName: alkemy-ong
+
+springfox:
+  documentation:
+    swaggerUi:
+      baseUrl: /api/docs
+    swagger:
+      v2:
+        path: /api/docs

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,11 +5,3 @@ amazonProperties:
   region: sa-east-1
   bucketName: alkemy-ong
 
-springfox:
-  documentation:
-    swaggerUi:
-      baseUrl: /api/docs
-    swagger:
-      v2:
-        path: /api/docs
-

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -4,11 +4,3 @@ amazonProperties:
   secretAccessKey: foo
   region: sa-east-1
   bucketName: alkemy-ong
-
-springfox:
-  documentation:
-    swaggerUi:
-      baseUrl: /api/docs
-    swagger:
-      v2:
-        path: /api/docs


### PR DESCRIPTION
Sumary:
 - switch swagger for springdoc because swagger doesnt work.
 - the url for ui is localhost:8080/api/docs/swagger-ui
 - in the explorer puts /api/docs to display the documentation:
![swagger](https://user-images.githubusercontent.com/31217980/140537105-a920a615-7537-4c6f-83e4-96a15937fccf.PNG)

 