### PR TITLE
OT98-96: Added authentication tests

### DIFF
--- a/src/test/java/com/alkemy/ong/common/SecurityTestConfig.java
+++ b/src/test/java/com/alkemy/ong/common/SecurityTestConfig.java
@@ -1,0 +1,33 @@
+package com.alkemy.ong.common;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+public class SecurityTestConfig {
+
+  private static final String SECRET_KEY = "3c1dab2b9a676e66b332d2deef2129b0d775bcb8";
+  private static final String BEARER_TOKEN = "Bearer %s";
+  private static final String AUTHORITIES = "authorities";
+
+  public static String createToken(String subject, String role) {
+    List<GrantedAuthority> grantedAuthorities = AuthorityUtils
+        .commaSeparatedStringToAuthorityList(role);
+
+    String token = Jwts.builder()
+        .claim(AUTHORITIES,
+            grantedAuthorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList()))
+        .setSubject(subject)
+        .setIssuedAt(new Date(System.currentTimeMillis()))
+        .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10))
+        .signWith(SignatureAlgorithm.HS256, SECRET_KEY.getBytes(StandardCharsets.UTF_8)).compact();
+    return String.format(BEARER_TOKEN, token);
+  }
+}

--- a/src/test/java/com/alkemy/ong/integration/AuthenticatedUserDetailsIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/AuthenticatedUserDetailsIntegrationTest.java
@@ -1,0 +1,69 @@
+package com.alkemy.ong.integration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.alkemy.ong.common.SecurityTestConfig;
+import com.alkemy.ong.config.ApplicationRole;
+import com.alkemy.ong.model.entity.Role;
+import com.alkemy.ong.model.entity.User;
+import com.alkemy.ong.model.request.UserAuthenticationRequest;
+import com.alkemy.ong.model.response.UserAuthenticatedMeResponse;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.assertj.core.util.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AuthenticatedUserDetailsIntegrationTest extends AbstractBaseIntegrationTest {
+
+  @Test
+  public void shouldMeSuccessfullyUser() {
+    when(authenticationManager.authenticate(any())).thenReturn(null);
+    when(userRepository.findByEmail(eq("imontovio@alkemy.com"))).thenReturn(
+        stubUser(ApplicationRole.USER.getFullRoleName()));
+
+    String jwt = SecurityTestConfig.createToken("imontovio@alkemy.com",
+        ApplicationRole.USER.getFullRoleName());
+    headers.set("Authorization", jwt);
+    HttpEntity<UserAuthenticationRequest> entity = new HttpEntity<>(headers);
+
+    ResponseEntity<UserAuthenticatedMeResponse> response = restTemplate.exchange(
+        createURLWithPort("/auth/me"), HttpMethod.GET, entity, UserAuthenticatedMeResponse.class);
+
+    Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+    Assert.assertEquals("Ignacio", response.getBody().getFirstName());
+    Assert.assertEquals("Montovio", response.getBody().getLastName());
+    Assert.assertEquals("imontovio@alkemy.com", response.getBody().getEmail());
+    Assert.assertEquals("https://foo.jpg", response.getBody().getPhoto());
+  }
+
+  private Role stubRole(String name) {
+    Role role = new Role();
+    role.setName(name);
+    return role;
+  }
+
+  private User stubUser(String role) {
+    User user = new User();
+    user.setEmail("imontovio@alkemy.com");
+    user.setPhoto("https://foo.jpg");
+    user.setFirstName("Ignacio");
+    user.setLastName("Montovio");
+    user.setPassword("foo12345");
+    user.setRoles(Lists.list(stubRole(role)));
+    user.setTimestamp(Timestamp.from(Instant.now()));
+    user.setSoftDeleted(false);
+    return user;
+  }
+}

--- a/src/test/java/com/alkemy/ong/integration/UserRegisterIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/UserRegisterIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -50,7 +51,7 @@ public class UserRegisterIntegrationTest extends AbstractBaseIntegrationTest {
   }
 
   @Test
-  public void shouldReturnJwtToken() {
+  public void shouldRegisterSuccessfully() {
     when(roleService.findBy(eq(ApplicationRole.USER.getFullRoleName())))
         .thenReturn(stubRole("USER"));
     when(userRepository.save(isA(User.class))).thenReturn(stubUser("USER"));
@@ -67,6 +68,9 @@ public class UserRegisterIntegrationTest extends AbstractBaseIntegrationTest {
         createURLWithPort("/auth/register"), HttpMethod.POST, entity, UserRegisterResponse.class);
 
     Assert.assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    Assert.assertEquals(response.getBody().getFirstsName(), registerRequest.getFirstName());
+    Assert.assertEquals(response.getBody().getLastName(), registerRequest.getLastName());
+    Assert.assertEquals(response.getBody().getEmail(), registerRequest.getEmail());
     Assert.assertTrue(jwtUtil.validateToken(response.getBody().getJwt(), stubUser("USER")));
   }
 


### PR DESCRIPTION
COMO desarrollador
QUIERO disponer de tests de los endpoints de /authentication
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.

Evidencia:
![imagen](https://user-images.githubusercontent.com/49342337/141211994-0a9b7661-adce-410c-a5bc-223a0a35e71b.png)
